### PR TITLE
Send unsold tokens to the foundation

### DIFF
--- a/contracts/RenderTokenCrowdsale.sol
+++ b/contracts/RenderTokenCrowdsale.sol
@@ -61,12 +61,16 @@ contract RenderTokenCrowdsale is CappedCrowdsale, FinalizableCrowdsale {
   // the remaining tokens
   function finalization() internal {
     uint256 tokensSold = token.totalSupply();
+    uint256 finalTotalSupply = cap.mul(rate).mul(4);
 
-    uint256 foundationTokens = tokensSold.mul(26000).div(10000);
-    uint256 foundersTokens = tokensSold.mul(4000).div(10000);
-
-    token.mint(foundationAddress, foundationTokens);
+    // send the 10% of the final total supply to the founders
+    uint256 foundersTokens = finalTotalSupply.div(10);
     token.mint(foundersAddress, foundersTokens);
+
+    // send the 65% plus the unsold tokens in ICO to the foundation
+    uint256 foundationTokens = finalTotalSupply.sub(tokensSold)
+      .sub(foundersTokens);
+    token.mint(foundationAddress, foundationTokens);
 
     super.finalization();
   }

--- a/test/Crowdsale.js
+++ b/test/Crowdsale.js
@@ -109,7 +109,7 @@ contract('Render Token Crowdsale', function(accounts) {
     const foundersAddress = accounts[3];
     const finalTotalSupply = 2147483648;
     const initialWalletBalance = parseFloat(await web3.eth.getBalance(wallet));
-    var totalSupply = 0;
+    var tokensSold = 0;
 
     console.log('Start block', startBlock);
     console.log('End block', endBlock);
@@ -146,11 +146,11 @@ contract('Render Token Crowdsale', function(accounts) {
     // buying all tokens from 3 accounts
 
     await crowdsale.sendTransaction({value: web3.toWei(100000), from: accounts[5]});
-    totalSupply += parseFloat(web3.toWei(100000)*1200);
+    tokensSold += parseFloat(web3.toWei(100000)*1200);
     await crowdsale.sendTransaction({value: web3.toWei(200000), from: accounts[6]});
-    totalSupply += parseFloat(web3.toWei(200000)*1200);
+    tokensSold += parseFloat(web3.toWei(200000)*1200);
     await crowdsale.buyTokens(accounts[8], {value: web3.toWei(147392.4266666667), from: accounts[7]});
-    totalSupply += parseFloat(web3.toWei(147392.4266666667)*1200);
+    tokensSold += parseFloat(web3.toWei(147392.4266666667)*1200);
 
     assert.equal(maxTokensICO, parseInt(help.parseRNDR(await token.totalSupply())));
 
@@ -176,17 +176,14 @@ contract('Render Token Crowdsale', function(accounts) {
     , help.formatRNDR(1));
 
     assert.equal(
-      totalSupply*2.6,
-      parseFloat(await token.balanceOf(foundationAddress))
+      parseInt(finalTotalSupply*0.1),
+      parseInt(help.parseRNDR(await token.balanceOf(foundersAddress)))
     );
+
     assert.equal(
-      totalSupply*0.4,
-      parseFloat(await token.balanceOf(foundersAddress))
+      parseInt(finalTotalSupply*0.9 - help.parseRNDR(tokensSold)),
+      parseInt(help.parseRNDR(await token.balanceOf(foundationAddress)))
     );
-
-    totalSupply += (totalSupply*2.6)+(totalSupply*0.4);
-
-    assert.equal(finalTotalSupply, parseInt(help.parseRNDR(totalSupply)));
 
     assert.equal(true, await token.mintingFinished());
 
@@ -210,7 +207,8 @@ contract('Render Token Crowdsale', function(accounts) {
     const wallet = accounts[1];
     const foundationAddress = accounts[2];
     const foundersAddress = accounts[3];
-    var totalSupply = 0;
+    const finalTotalSupply = 2147483648;
+    var tokensSold = 0;
 
     console.log('Start block', startBlock);
     console.log('End block', endBlock);
@@ -247,11 +245,11 @@ contract('Render Token Crowdsale', function(accounts) {
     // buying all tokens from 2 accounts
 
     await crowdsale.sendTransaction({value: web3.toWei(100000), from: accounts[5]});
-    totalSupply += parseFloat(web3.toWei(100000)*1200);
+    tokensSold += parseFloat(web3.toWei(100000)*1200);
     await crowdsale.sendTransaction({value: web3.toWei(150000), from: accounts[6]});
-    totalSupply += parseFloat(web3.toWei(150000)*1200);
+    tokensSold += parseFloat(web3.toWei(150000)*1200);
 
-    assert.equal(totalSupply, parseFloat(await token.totalSupply()));
+    assert.equal(tokensSold, parseFloat(await token.totalSupply()));
 
     // waiting for end of ICO
 
@@ -262,21 +260,20 @@ contract('Render Token Crowdsale', function(accounts) {
     crowdsale.finalize();
 
     assert.equal(
-      totalSupply*2.6,
-      parseFloat(await token.balanceOf(foundationAddress))
-    );
-    assert.equal(
-      totalSupply*0.4,
-      parseFloat(await token.balanceOf(foundersAddress))
+      parseInt(finalTotalSupply*0.1),
+      parseInt(help.parseRNDR(await token.balanceOf(foundersAddress)))
     );
 
-    totalSupply += (totalSupply*2.6)+(totalSupply*0.4);
+    assert.equal(
+      parseInt(finalTotalSupply*0.9 - help.parseRNDR(tokensSold)),
+      parseInt(help.parseRNDR(await token.balanceOf(foundationAddress)))
+    );
 
     assert.equal(true, await token.mintingFinished());
 
     assert.equal(
-      totalSupply,
-      parseFloat(await token.totalSupply())
+      finalTotalSupply,
+      parseInt(help.parseRNDR(await token.totalSupply()))
     );
 
   });


### PR DESCRIPTION
The final total supply will equals the max amount of tokens that can be sold on the ICO multiplied by 4. Because  a maximum of the 25% of total supply of tokens can be sold in the ICO. If at the end of the crowdsale there is tokens unsold they will go to the foundation, and the 10% of the final total supply will go to the founders.